### PR TITLE
Fixed avp thread safety

### DIFF
--- a/src/avp.c
+++ b/src/avp.c
@@ -1327,7 +1327,7 @@ void FindNearestAtoms(PDB *pdb, VOIDS *voids)
    VOIDS *v;
    POINTLIST *p;
 
-#ifdef OMP
+#ifdef _OPENMP
    VOIDS **voidarray;
    int   nvoids, i;
 

--- a/src/avp.c
+++ b/src/avp.c
@@ -1729,6 +1729,7 @@ BOOL AtomNear(PDB *pdb, REAL x, REAL y, REAL z, REAL probeSize,
 
 {
    static PDB **pdbArray = NULL;
+#pragma omp threadprivate(pdbArray)
    static int natoms     = 0;
    VEC3F      point;
    REAL       cutoffSq,


### PR DESCRIPTION
Finally found the bug that made AVP stall randomly. When variables are made static, in this case pdbArray, they are no longer threadsafe and we have to tell openMP to just refer to the master thread version using `#pragma omp threadprivate(pdbArray)` explained [here](https://www.ibm.com/support/knowledgecenter/SSGH3R_10.1.0/com.ibm.xlcpp101.aix.doc/compiler_ref/prag_omp_threadprivate.html).
So far I tested this out with gcc >= 4.8., and the test script runs to completion without any issues.