### PR TITLE
replace critical with atomic

### DIFF
--- a/src/avp.c
+++ b/src/avp.c
@@ -1352,10 +1352,8 @@ void FindNearestAtoms(PDB *pdb, VOIDS *voids)
 
       for(p=v->pointlist; p!=NULL; NEXT(p))
       {
-         PDB *tmp;
-         tmp = FindTheNearestAtom(pdb, p);
-#pragma omp critical
-         p->nearest = tmp;
+#pragma omp atomic write
+         p->nearest = FindTheNearestAtom(pdb, p);
       }
    }
 #else


### PR DESCRIPTION
* atomic write is more efficient than critical and can be used in this situation
* this makes the parallel version superior to the sequential version